### PR TITLE
feat(ui): enhance news screens with modern Material Design 3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,13 +88,14 @@ dependencies {
 
 
     // Image loader
-    // implementation("io.coil-kt:coil-compose:3.4.0")
-//    implementation("io.coil-kt:coil-compose")
     implementation("io.coil-kt:coil-compose:2.7.0")
-
 
     // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+
+    // UI - Icon
+    implementation("androidx.compose.material:material-icons-extended")
+
 
     // Testing
     testImplementation(libs.junit)

--- a/app/src/main/java/com/yogiveloper/yonewsai/modules/home_news/presentation/detail/NewsDetailScreen.kt
+++ b/app/src/main/java/com/yogiveloper/yonewsai/modules/home_news/presentation/detail/NewsDetailScreen.kt
@@ -2,52 +2,342 @@ package com.yogiveloper.yonewsai.modules.home_news.presentation.detail
 
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.OpenInBrowser
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.*
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 import com.yogiveloper.yonewsai.modules.home_news.domain.model.Article
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NewsDetailScreen(article: Article?, onBack: () -> Unit) {
-    Scaffold(topBar = {
-        TopAppBar(
-            title = { Text(article?.title ?: "Detail" , maxLines = 2 ) },
-            navigationIcon = {
-                IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, contentDescription = "Back") }
-            }
-        )
-    }) { padding ->
-        val ctx = LocalContext.current
-        Column(modifier = Modifier
-            .padding(padding)
-            .verticalScroll(rememberScrollState())
-            .padding(12.dp)
-        ) {
-            article?.urlToImage?.let {
-                AsyncImage(model = it, contentDescription = null, modifier = Modifier.fillMaxWidth().height(220.dp))
-                Spacer(Modifier.height(8.dp))
-            }
-            Text(text = article?.title ?: "", style = MaterialTheme.typography.headlineSmall)
-            Spacer(Modifier.height(8.dp))
-            Text(text = article?.content ?: article?.description ?: "No content", style = MaterialTheme.typography.bodyLarge)
-            Spacer(Modifier.height(12.dp))
-            Button(onClick = {
-                article?.url?.let { url ->
-                    ctx.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+    val ctx = LocalContext.current
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "Article Details",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = {
+                            val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                                type = "text/plain"
+                                putExtra(Intent.EXTRA_SUBJECT, article?.title ?: "")
+                                putExtra(Intent.EXTRA_TEXT, "${article?.title}\n\n${article?.url}")
+                            }
+                            ctx.startActivity(Intent.createChooser(shareIntent, "Share via"))
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Share,
+                            contentDescription = "Share",
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    titleContentColor = MaterialTheme.colorScheme.onSurface
+                )
+            )
+        }
+    ) { padding ->
+        if (article == null) {
+            EmptyArticleState(modifier = Modifier.padding(padding))
+        } else {
+            ArticleDetailContent(
+                article = article,
+                modifier = Modifier.padding(padding),
+                onOpenOriginal = {
+                    article.url?.let { url ->
+                        ctx.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                    }
                 }
-            }) {
-                Text("Open original")
+            )
+        }
+    }
+}
+
+@Composable
+private fun EmptyArticleState(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "📄",
+                style = MaterialTheme.typography.displayLarge
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "Article not found",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}
+
+@Composable
+private fun ArticleDetailContent(
+    article: Article,
+    modifier: Modifier = Modifier,
+    onOpenOriginal: () -> Unit
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .verticalScroll(rememberScrollState())
+    ) {
+        article.urlToImage?.let { imageUrl ->
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(280.dp)
+            ) {
+                AsyncImage(
+                    model = imageUrl,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(
+                            Brush.verticalGradient(
+                                colors = listOf(
+                                    Color.Transparent,
+                                    Color.Black.copy(alpha = 0.6f)
+                                ),
+                                startY = 100f
+                            )
+                        )
+                )
             }
         }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp)
+        ) {
+            if (!article.sourceName.isNullOrEmpty()) {
+                Surface(
+                    shape = RoundedCornerShape(8.dp),
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                ) {
+                    Text(
+                        text = article.sourceName.uppercase(),
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
+            }
+
+            Text(
+                text = article.title ?: "",
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 20.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    if (!article.author.isNullOrEmpty()) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = "By ",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Text(
+                                text = article.author,
+                                style = MaterialTheme.typography.bodySmall,
+                                fontWeight = FontWeight.SemiBold,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    }
+
+                    if (!article.publishedAt.isNullOrEmpty()) {
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = formatPublishedDate(article.publishedAt),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+
+            HorizontalDivider(
+                modifier = Modifier.padding(vertical = 16.dp),
+                thickness = DividerDefaults.Thickness, color = MaterialTheme.colorScheme.outlineVariant
+            )
+
+            if (!article.description.isNullOrEmpty()) {
+                Text(
+                    text = article.description,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.padding(bottom = 16.dp),
+                    lineHeight = MaterialTheme.typography.titleMedium.lineHeight
+                )
+            }
+
+            Text(
+                text = article.content ?: article.description ?: "No content available.",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                lineHeight = MaterialTheme.typography.bodyLarge.lineHeight,
+                modifier = Modifier.padding(bottom = 24.dp)
+            )
+
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 24.dp),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer
+                ),
+                elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+            ) {
+                Column(
+                    modifier = Modifier.padding(20.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = "Want to read more?",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        modifier = Modifier.padding(bottom = 12.dp)
+                    )
+
+                    Button(
+                        onClick = onOpenOriginal,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(52.dp),
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.primary
+                        )
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.OpenInBrowser,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = "Read Full Article",
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+            }
+
+            Text(
+                text = "This is a preview. Full article available at the source.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp),
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center
+            )
+        }
+    }
+}
+
+// Helper function to format date TODO Utils
+private fun formatPublishedDate(publishedAt: String): String {
+    return try {
+        val parts = publishedAt.split("T")
+        if (parts.size >= 2) {
+            val date = parts[0]
+            val time = parts[1].split(":").take(2).joinToString(":")
+            "$date at $time"
+        } else {
+            publishedAt
+        }
+    } catch (e: Exception) {
+        publishedAt
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun NewsDetailScreenPreview() {
+    MaterialTheme {
+        NewsDetailScreen(
+            article = Article(
+                title = "Breaking News: Kotlin Compose Revolutionizes Android Development",
+                description = "Jetpack Compose is transforming how developers build Android UIs with its modern, declarative approach that simplifies the development process.",
+                sourceName = "Tech News Daily",
+                urlToImage = "https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/2GL6CGJ2H276MXKU5XT6XH6IYE.jpg&w=1440",
+                author = "Yogi Arif Widodo",
+                url = "https://example.com/article",
+                publishedAt = "2025-10-02T20:12:15Z",
+                content = "Jetpack Compose has emerged as a game-changer in Android development. The modern toolkit enables developers to build beautiful, responsive UIs with significantly less code than traditional View-based approaches. With its declarative syntax and powerful state management, Compose is quickly becoming the preferred choice for Android developers worldwide."
+            ),
+            onBack = {}
+        )
     }
 }

--- a/app/src/main/java/com/yogiveloper/yonewsai/modules/home_news/presentation/list/NewsListScreen.kt
+++ b/app/src/main/java/com/yogiveloper/yonewsai/modules/home_news/presentation/list/NewsListScreen.kt
@@ -1,14 +1,23 @@
 package com.yogiveloper.yonewsai.modules.home_news.presentation.list
 
-
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -29,84 +38,331 @@ fun NewsListScreen(
         onOpenDetail = onOpenDetail
     )
 }
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NewsListContent(
-        articles: List<Article>,
-        isLoading: Boolean,
-        error: String?,
-        onRefresh: () -> Unit,
-        onOpenDetail: (Article) -> Unit
+    articles: List<Article>,
+    isLoading: Boolean,
+    error: String?,
+    onRefresh: () -> Unit,
+    onOpenDetail: (Article) -> Unit
 ) {
     Scaffold(
         topBar = {
             TopAppBar(
-                { Text( "YoNewsAi - Top Headlines") }
-            )
-        }) { padding ->
-        Box(modifier = Modifier
-            .fillMaxSize()
-            .padding(padding)) {
-                if (isLoading) {
-                    CircularProgressIndicator(modifier = Modifier.align(alignment = Alignment.Center))
-                } else if (error != null) {
-                    Column(
-                        modifier = Modifier.fillMaxSize(),
-                        verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Text(text = "Error: $error")
-                        Spacer(modifier = Modifier.height(8.dp))
-                        Button(onClick = onRefresh) { Text("Retry") }
+                title = {
+                    Text(
+                        "YoNewsAI",
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                actions = {
+                    IconButton(onClick = onRefresh) {
+                        Icon(
+                            imageVector = Icons.Default.Refresh,
+                            contentDescription = "Refresh",
+                            tint = MaterialTheme.colorScheme.primary
+                        )
                     }
-                } else {
-                    LazyColumn(modifier = Modifier.fillMaxSize()) {
-                        items(articles) { article ->
-                            ArticleCard(article = article, onClick = { onOpenDetail(article) })
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    titleContentColor = MaterialTheme.colorScheme.onSurface
+                )
+            )
+        }
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .background(MaterialTheme.colorScheme.background)
+        ) {
+            when {
+                isLoading -> {
+                    LoadingState()
+                }
+                error != null -> {
+                    ErrorState(error = error, onRetry = onRefresh)
+                }
+                articles.isEmpty() -> {
+                    EmptyState()
+                }
+                else -> {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(vertical = 8.dp)
+                    ) {
+                        items(articles, key = { it.url ?: it.title ?: "" }) { article ->
+                            ArticleCard(
+                                article = article,
+                                onClick = { onOpenDetail(article) }
+                            )
                         }
                     }
                 }
-            }
-    }
-}
-
-@Composable
-fun ArticleCard(article: Article, onClick: () -> Unit) {
-    Card(modifier = Modifier
-        .fillMaxWidth()
-        .padding(8.dp)
-        .clickable(onClick = onClick)
-    ) {
-        Row(modifier = Modifier.padding(8.dp)) {
-            val imageUrl = article.urlToImage
-            if (!imageUrl.isNullOrEmpty()) {
-                AsyncImage(model = imageUrl, contentDescription = null, modifier = Modifier.size(96.dp))
-            }
-            Spacer(Modifier.width(8.dp))
-            Column(modifier = Modifier.fillMaxWidth()) {
-                Text(article.title ?: "", style = MaterialTheme.typography.titleMedium, maxLines = 2)
-                Text(article.description ?: "", style = MaterialTheme.typography.bodyMedium, maxLines = 2)
-                Text(article.sourceName ?: "", style = MaterialTheme.typography.bodySmall)
             }
         }
     }
 }
 
+@Composable
+private fun LoadingState() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(48.dp),
+            color = MaterialTheme.colorScheme.primary
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "Loading news...",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun ErrorState(error: String, onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "😕",
+            style = MaterialTheme.typography.displayLarge
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "Oops! Something went wrong",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = error,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(
+            onClick = onRetry,
+            modifier = Modifier
+                .fillMaxWidth(0.6f)
+                .height(48.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Refresh,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Try Again")
+        }
+    }
+}
+
+@Composable
+private fun EmptyState() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "📰",
+            style = MaterialTheme.typography.displayLarge
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "No news available",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Check back later for updates",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+fun ArticleCard(article: Article, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 2.dp,
+            pressedElevation = 8.dp
+        ),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column {
+            val imageUrl = article.urlToImage
+            if (!imageUrl.isNullOrEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp)
+                ) {
+                    AsyncImage(
+                        model = imageUrl,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)),
+                        contentScale = ContentScale.Crop
+                    )
+
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(
+                                Brush.verticalGradient(
+                                    colors = listOf(
+                                        Color.Transparent,
+                                        Color.Black.copy(alpha = 0.3f)
+                                    )
+                                )
+                            )
+                    )
+
+                    if (!article.sourceName.isNullOrEmpty()) {
+                        Surface(
+                            modifier = Modifier
+                                .align(Alignment.TopEnd)
+                                .padding(12.dp),
+                            shape = RoundedCornerShape(8.dp),
+                            color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.9f)
+                        ) {
+                            Text(
+                                text = article.sourceName,
+                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer
+                            )
+                        }
+                    }
+                }
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                Text(
+                    text = article.title ?: "",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+
+                if (!article.description.isNullOrEmpty()) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = article.description,
+                        style = MaterialTheme.typography.bodyMedium,
+                        maxLines = 3,
+                        overflow = TextOverflow.Ellipsis,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    if (!article.author.isNullOrEmpty()) {
+                        Text(
+                            text = article.author,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+
+                    if (!article.publishedAt.isNullOrEmpty()) {
+                        Text(
+                            text = formatPublishedDate(article.publishedAt),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Helper function to format date Todo Utils
+private fun formatPublishedDate(publishedAt: String): String {
+    return try {
+        val parts = publishedAt.split("T")
+        if (parts.isNotEmpty()) parts[0] else publishedAt
+    } catch (e: Exception) {
+        publishedAt
+    }
+}
 
 @Preview(showBackground = true)
 @Composable
 fun ArticleCardPreview() {
-    ArticleCard(
-        article = Article(
-            title = "Breaking News: Kotlin Compose Rocks 🚀",
-            description = "Compose simplifies Android UI development with a declarative approach.",
-            sourceName = "OpenAI News",
-            urlToImage = "https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/2GL6CGJ2H276MXKU5XT6XH6IYE.jpg&w=1440",
-            author = "Yogi Arif Widodo",
-            url = "https://www.washingtonpost.com/politics/2025/10/02/trump-fda-abortion-pill/",
-            publishedAt = "2025-10-02T20:12:15Z",
-            content = "The FDA has little latitude to reject generic versions of approved drugs, but that hasn’t stopped an outrcry from abortion opponents."
-        ),
-        onClick = {}
-    )
+    MaterialTheme {
+        ArticleCard(
+            article = Article(
+                title = "Breaking News: Kotlin Compose Rocks 🚀",
+                description = "Compose simplifies Android UI development with a declarative approach that makes building beautiful UIs easier than ever.",
+                sourceName = "OpenAI News",
+                urlToImage = "https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/2GL6CGJ2H276MXKU5XT6XH6IYE.jpg&w=1440",
+                author = "Yogi Arif Widodo",
+                url = "https://www.washingtonpost.com/politics/2025/10/02/trump-fda-abortion-pill/",
+                publishedAt = "2025-10-02T20:12:15Z",
+                content = "The FDA has little latitude to reject generic versions of approved drugs."
+            ),
+            onClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun LoadingStatePreview() {
+    MaterialTheme {
+        LoadingState()
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ErrorStatePreview() {
+    MaterialTheme {
+        ErrorState(error = "Network connection failed", onRetry = {})
+    }
 }


### PR DESCRIPTION
- Redesign NewsListScreen with improved card layout and visual hierarchy
- Add hero image with gradient overlay and source badges
- Implement enhanced states (loading, error, empty)
- Redesign NewsDetailScreen with better typography and spacing
- Add share functionality and improved CTA section
- Enhance metadata display with author and formatted date
- Improve overall color scheme and component spacing
- Add preview composables for better development experience