### PR TITLE
feat(viewmodel): add debug logging and prevent race conditions

### DIFF
--- a/app/src/main/java/com/yogiveloper/yonewsai/core/util/FlowExt.kt
+++ b/app/src/main/java/com/yogiveloper/yonewsai/core/util/FlowExt.kt
@@ -1,0 +1,21 @@
+package com.yogiveloper.yonewsai.core.util
+
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Extension function to log all emissions from a StateFlow.
+ * Useful for debugging UI state changes in ViewModels.
+ */
+fun <T> StateFlow<T>.logChanges(
+    tag: String,
+    scope: CoroutineScope
+) {
+    scope.launch {
+        this@logChanges.collect {
+            Log.d(tag, "UI state updated: $it")
+        }
+    }
+}

--- a/app/src/main/java/com/yogiveloper/yonewsai/modules/home_news/data/repository/NewsRepositoryImpl.kt
+++ b/app/src/main/java/com/yogiveloper/yonewsai/modules/home_news/data/repository/NewsRepositoryImpl.kt
@@ -10,7 +10,7 @@ import javax.inject.Singleton
 
 @Singleton
 class NewsRepositoryImpl @Inject constructor(
-    private val api: NewsApiService
+    private val api: NewsApiService,
 ) : NewsRepository {
 
     /**
@@ -36,6 +36,7 @@ class NewsRepositoryImpl @Inject constructor(
              * articleCache.putAll(...) is then used to efficiently
              * add all the new articles to the cache in one go.
              * */
+            Log.d("NewsRepositoryImpl", "Caching ${domainArticles.size} articles")
             articleCache.clear()
             articleCache.putAll(domainArticles.associateBy { it.id })
 

--- a/app/src/main/java/com/yogiveloper/yonewsai/modules/home_news/presentation/detail/NewsDetailViewModel.kt
+++ b/app/src/main/java/com/yogiveloper/yonewsai/modules/home_news/presentation/detail/NewsDetailViewModel.kt
@@ -4,9 +4,11 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.yogiveloper.yonewsai.core.util.Resource
+import com.yogiveloper.yonewsai.core.util.logChanges
 import com.yogiveloper.yonewsai.modules.home_news.domain.model.Article
 import com.yogiveloper.yonewsai.modules.home_news.domain.usecase.GetArticleByIdUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -26,14 +28,23 @@ class NewsDetailViewModel @Inject constructor(
     val uiState: StateFlow<NewsDetailUiState> = _uiState
 
     init {
+        /**
+         * because currently a data (repo) is on simple cache
+         * and ID its already on state
+         * safe to load directly
+         * */
         val articleID = savedStateHandle.get<Int>("articleID")
         if(articleID !== null){
             fetchArticleByID(articleID)
         }
+        uiState.logChanges("NewsDetailViewModel", viewModelScope)
     }
 
+    // prevent race-condition ex: on swipe refresh or fast rotate
+    private var fetchJob: Job? = null
     private fun fetchArticleByID(id: Int){
-        viewModelScope.launch {
+        fetchJob?.cancel()  // cancel old job if any
+        fetchJob = viewModelScope.launch {
             when(val r = getArticleByIdUseCase(id)){
                 is Resource.Success -> {
                     _uiState.value = _uiState.value.copy(article = r.data)

--- a/app/src/main/java/com/yogiveloper/yonewsai/modules/home_news/presentation/home/NewsHomeViewModel.kt
+++ b/app/src/main/java/com/yogiveloper/yonewsai/modules/home_news/presentation/home/NewsHomeViewModel.kt
@@ -1,7 +1,5 @@
 package com.yogiveloper.yonewsai.modules.home_news.presentation.home
 
-import android.util.Log
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.yogiveloper.yonewsai.core.util.Resource

--- a/app/src/main/java/com/yogiveloper/yonewsai/modules/home_news/presentation/home/NewsHomeViewModel.kt
+++ b/app/src/main/java/com/yogiveloper/yonewsai/modules/home_news/presentation/home/NewsHomeViewModel.kt
@@ -1,12 +1,15 @@
 package com.yogiveloper.yonewsai.modules.home_news.presentation.home
 
 import android.util.Log
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.yogiveloper.yonewsai.core.util.Resource
+import com.yogiveloper.yonewsai.core.util.logChanges
 import com.yogiveloper.yonewsai.modules.home_news.domain.model.Article
 import com.yogiveloper.yonewsai.modules.home_news.domain.usecase.GetTopHeadlinesUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -21,21 +24,44 @@ data class NewsHomeUiState(
 
 @HiltViewModel
 class NewsHomeViewModel @Inject constructor(
-    private val getTopHeadlines: GetTopHeadlinesUseCase
+    private val getTopHeadlines: GetTopHeadlinesUseCase,
+    // private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(NewsHomeUiState())
     val uiState: StateFlow<NewsHomeUiState> = _uiState
 
     init {
-        fetchBreakingNews()
+        uiState.logChanges("NewsHomeViewModel", viewModelScope)
+        /**
+         * if API doesn't have cache mechanism should use these approach:
+         * (else this expensive solution)
+         * for HomeScreen should save on repo/local cache (Room/DataStore)
+         * */
+
+        /**
+         * if API doesn't have or have cache mechanism not problem use these approach:
+         * for DetailScreen should save ID on state
+         * then getArticleById from repo/local cache (Room/DataStore)
+         *  */
+
+        // val cached = savedStateHandle.get<List<Article>>("articles")
+        // if (cached != null) {
+        //    _uiState.value = _uiState.value.copy(articles = cached)
+        // } else {
+            fetchBreakingNews()
+        // }
+
     }
 
+    // prevent race-condition ex: on swipe refresh or fast rotate
+    private var fetchJob: Job? = null
     fun fetchBreakingNews(country: String = "us", category: String = "technology") {
-        Log.d("fetchBreakingNews", "fetchBreakingNews: called")
-        viewModelScope.launch {
+        fetchJob?.cancel()  // cancel old job if any
+        fetchJob = viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, error = null)
             when(val r = getTopHeadlines(country, category )){
                 is Resource.Success -> {
+                    // savedStateHandle["articles"] = r.data
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
                         articles = r.data,


### PR DESCRIPTION
This PR introduces improvements to the NewsHomeViewModel and NewsDetailViewModel to enhance debugging and ensure safer coroutine handling:
✨ What's Added

logChanges — a StateFlow extension function to log UI state updates for easier debugging.
Job cancellation logic in both NewsHomeViewModel and NewsDetailViewModel to prevent race conditions during data fetching (e.g., swipe-to-refresh, configuration changes).
Integration of logChanges into NewsHomeViewModel to trace state transitions more effectively.

🧠 Why

Debugging Compose lifecycle and state transitions can be tricky; logging helps visualize changes.
Preventing race conditions ensures data consistency and avoids overlapping coroutine executions.

📌 Notes

This is part of a broader effort to analyze Compose lifecycle behavior using coroutine patterns inspired by previous XML-based my old Jetpack projects on 2019.